### PR TITLE
Updated the  lexer.py code file.

### DIFF
--- a/src/cql/lexer.py
+++ b/src/cql/lexer.py
@@ -73,13 +73,8 @@ class CQLLexer:
 
     # ---------------------------------------------------
 
-    #: A string containing ignored characters (spaces and tabs)
+    #: A string containing ignored characters (spaces, tabs, and newlines)
     t_ignore = " \t\r\n\f\v"
-
-    def t_ignore_newline(self, tok: LexToken) -> None:
-        r"\n+"
-        # NOTE: not sure if required
-        tok.lexer.lineno += tok.value.count("\n")
 
     #: Error handling rule
     def t_error(self, tok: LexToken) -> None:
@@ -114,6 +109,3 @@ class CQLLexer:
                 break
 
             yield tok
-
-
-# ---------------------------------------------------------------------------


### PR DESCRIPTION
t_ignore_newline definition: The t_ignore_newline method is unnecessary because the regular expression r"\n+" is already handled by the t_ignore = " \t\r\n\f\v" statement. This line already tells the lexer to ignore all whitespace, including newlines, so the t_ignore_newline method could be removed to avoid redundancy. If the intent is to track line numbers (which seems to be implied by tok.lexer.lineno), you should ensure that's handled in a different part of the code.

fixed #1 